### PR TITLE
Système de Portes pour Nouvelles Scènes

### DIFF
--- a/Scripts/DoubleDoor.cs
+++ b/Scripts/DoubleDoor.cs
@@ -1,0 +1,53 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+//Permet de changer de scene avec une plaque de pression lorsque qu'il y a deux portes et que les joueur doivent donc emprunter 2 portes différentes
+//ATTENTION : Respecter les conventions établie dans PressurePlate
+//NE PAS OUBLIER : de relier manuellement le deux portes lors de la crétion de scene les objets entre eux !
+//NE PAS OUBLIER : Entrer le nom de la scene suivante
+public class DoubleDoor : PressurePlate
+{
+    /*
+     * Variables Publiques
+     */
+
+    //Nom de la scene suivante qu'il faudra charger.
+    public string nextSceneName;
+
+    //L'autre plaque de pression (de l'autre porte qui lui est liée)
+    //NE PAS OUBLIER : de relier manuellemant lors de la crétion de scene les objets entre eux !
+    public DoubleDoor autrePressurePlate;
+
+
+    /*
+     * Fonctions
+     */
+
+    //Fonction OnPressure() appellée si un player marche sur la plaque de pression,
+    //  SI (y a aussi un player sur autrePressurePlate) : elle téléporte les joueurs (elle charge la nouvelle scène)
+    //  SINON : Rien ne se passe
+    /**
+    * <summary>Détermine ce s'il faut faire qqc (et quoi) avec le player qui est sur la plaque</summary>
+    * 
+    * <param name="other">objet avec qui on a collisioné</param>
+    * 
+    * <returns>Return nothing</returns>
+    */
+    protected override void OnPressure(Collider2D other)
+    {
+        // SI (y a aussi un player sur autrePressurePlate) : elle téléporte les joueurs (elle charge la nouvelle scène)
+        //Check si le booléen de autrePressurePlate de la classe componente PressurePlate est true
+        if (autrePressurePlate.pressed == true)
+        {
+            //TODO : Enregistrer l'avancement
+            //GameManager.instance.SaveState();
+
+            //Charger la scene suivante
+            SceneManager.LoadScene(nextSceneName);
+        }
+        //SINON
+        //TODO : Changer la couleur de la lupiotte
+    }
+}

--- a/Scripts/PressurePlate.cs
+++ b/Scripts/PressurePlate.cs
@@ -1,0 +1,84 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+//PressurePlate sert à detecter la présence d'un individu sur l'objet sur lequel le script est
+//NE PAS OUBLIER : ajouter un composant BoxCollider2D
+//NE PAS OUBLIER : les joueur doivent avoir un composant BoxCollider2D
+//NE PAS OUBLIER : les joueur doivent avoir un composant RigidBody2D !!! (mettre la variable "Gravity Scale" à 0 car on est en TOP-DOWN (donc pas de gravitée))
+//NE PAS OUBLIER : cocher le isTrigger sur le composant BoxCollider2D !!!
+//ATTENTION : joueurs doivent avoir le tag "Player"
+public class PressurePlate : MonoBehaviour
+{
+    /*
+     * Variables Protégées
+     * Accessible par les classes filles
+     */
+
+    //Bolléens qui sait si la plaque est acctuellement préssée ou non
+    protected bool pressed = false;
+
+    //Stocke le Player en contact avec la plaque
+    protected List<Collider2D> player;
+
+
+    /*
+     * Fonctions
+     */
+
+    /**
+    * <summary>Appelée lorsque qqc entre en contact avec la plaque.
+    *   Seulement si c un joueur : elle indique que l'on est en contat avec la plaque + call OnPressure()</summary>
+    * 
+    * <param name="other">objet avec qui est sur la plaque</param>
+    * 
+    * <returns>Return nothing</returns>
+    */
+    private void OnTriggerEnter2D(Collider2D other)
+    {
+        //Si ce qui est entrée en collision est un joueur
+        if (other.tag == "Player")
+        {
+            //On indique que la plaque est préssée
+            pressed = true;
+            //On stocke le player (au cas où qu'on en ai besoin plus tard pour un ajout de features (mais pour l'instant ça sert à rien)
+            player.Add(other);
+            //On réalise l'action
+            OnPressure(other);
+        }
+    }
+
+    /**
+    * <summary>Appelée lorsque l'on sort du contact avec la plaque.
+    *   Seulement si c un joueur : elle indique que l'on n'est plus en contat avec la plaque</summary>
+    * 
+    * <param name="other">objet avec qui est sur la plaque</param>
+    * 
+    * <returns>Return nothing</returns>
+    */
+    private void OnTriggerExit2D(Collider2D other)
+    {
+        //Si ce qui sort est un joueur
+        if (other.tag == "Player")
+        {
+            //On indique que la plaque n'est plus préssée
+            pressed = false;
+            //On supprime le player stocker (il n'y a plus de player sur la plaque)
+            player.Remove(other);
+        }
+    }
+
+    //Fonction OnPressure() appellée si un player marche sur la plaque de pression
+    //IMPORTANT : cette fonction à pour vocation à être modifier dans les classe fille (avec override)
+    /**
+    * <summary>Détermine ce s'il faut faire qqc (et quoi) avec le player qui est sur la plaque</summary>
+    * 
+    * <param name="other">objet avec qui on a collisioné</param>
+    * 
+    * <returns>Return nothing</returns>
+    */
+    protected virtual void OnPressure(Collider2D other)
+    {
+        return;
+    }
+}

--- a/Scripts/SingleDoor.cs
+++ b/Scripts/SingleDoor.cs
@@ -1,0 +1,39 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+//Permet de changer de scene avec une plaque de pression lorsque qu'il n'y a qu'une seul est unique porte (les deux joueurs empruntent la même porte)
+//ATTENTION : Respecter les conventions établie dans PressurePlate
+//NE PAS OUBLIER : Entrer le nom de la scene suivante
+public class SingleDoor : PressurePlate
+{
+    /*
+     * Variables Publiques
+     */
+
+    //Nom de la scene suivante qu'il faudra charger.
+    public string nextSceneName;
+
+
+    /*
+     * Fonctions
+     */
+
+    //Fonction OnPressure() appellée si un player marche sur la plaque de pression, elle téléporte les joueurs (elle charge la nouvelle scène)
+    /**
+    * <summary>Détermine ce s'il faut faire qqc (et quoi) avec le player qui est sur la plaque</summary>
+    * 
+    * <param name="other">objet avec qui on a collisioné</param>
+    * 
+    * <returns>Return nothing</returns>
+    */
+    protected override void OnPressure(Collider2D other)
+    {
+        //TODO : Enregistrer l'avancement
+        //GameManager.instance.SaveState();
+
+        //Charger la scene suivante
+        SceneManager.LoadScene(nextSceneName);
+    }
+}


### PR DESCRIPTION
Pour l'instant le chargement de la nouvelle scène se fait instantanément dès que les condition sont réunies (sur la plaque, etc)
TODO : Plus tard il serait intéressant de demander au jouer de confirmer sa volonté de changer de salle en appuyant sur une touche du clavier
TODO : Il faut, pour l'instant entrer manuellement le nom des scene suivantes dan unity mais il faudra plus tard le faire remplir par la génération procédurale de Tim

Il y a deux possibilités : 
1. Porte Unique
2. Porte Double

- PressurePlate.cs est une classe Mère : elle NE doit PAS être ajouter sur l'objet (on ajoute les classes filles)

> Elle sert à detecter la présence d'un individu sur l'objet sur lequel le script est. 

_NE PAS OUBLIER : ajouter un composant BoxCollider2D
NE PAS OUBLIER : les joueur doivent avoir un composant BoxCollider2D
NE PAS OUBLIER : les joueur doivent avoir un composant RigidBody2D !!! (mettre la variable "Gravity Scale" à 0 car on est en TOP-DOWN (donc pas de gravitée))
NE PAS OUBLIER : cocher le isTrigger sur le composant BoxCollider2D !!!
ATTENTION : joueurs doivent avoir le tag "Player"_

- SingleDoor.cs est une classe fille de "PressurePlate" : 

> Permet de changer de scène avec une plaque de pression lorsque qu'il n'y a qu'une seul est unique porte (les deux joueurs empruntent la même porte)

_ATTENTION : Respecter les conventions établie dans PressurePlate
NE PAS OUBLIER : Entrer le nom de la scene suivante dans unity_

- DoubleDoor.cs est une classe fille de "PressurePlate" : 

> Permet de changer de scene avec une plaque de pression lorsque qu'il y a deux portes et que les joueur doivent donc emprunter 2 portes différentes

_ATTENTION : Respecter les conventions établie dans PressurePlate
NE PAS OUBLIER : de relier manuellement le deux portes lors de la crétion de scene les objets entre eux !
NE PAS OUBLIER : Entrer le nom de la scene suivante_